### PR TITLE
fix: NewsAPI를 Naver API로 교체

### DIFF
--- a/Front/yososu_map/package.json
+++ b/Front/yososu_map/package.json
@@ -19,6 +19,7 @@
     "web-vitals": "^1.0.1",
     "yarn": "^1.22.17"
   },
+  "proxy": "https://openapi.naver.com",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/Front/yososu_map/src/components/NewsPage/NewsList.js
+++ b/Front/yososu_map/src/components/NewsPage/NewsList.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import NewsItem from './NewsItem';
 import axios from 'axios';
 import { Row } from 'react-bootstrap';
+import { alignPropType } from 'react-bootstrap/esm/types';
 
 const NewsListBlock = styled.div`
     box-sizing: border-box;
@@ -30,16 +31,29 @@ const NewsListBlock = styled.div`
 const NewsList = () => {
     const [articles, setArticles] = useState(null);
     const [loading, setLoading] = useState(false);
+    const client_id = 'PVEk2NtFI54kx8Dyjibd';
+    const client_secret = 'ROeiZLLqsO';
 
     useEffect(() => {
         // async를 사용하는 함수 따로 선언
         const fetchData = async () => {
             setLoading(true);
             try {
-                const response = await axios.get(
-                    'https://newsapi.org/v2/everything?q=요소수&sortBy=publishedAt&pageSize=4&apiKey=a4a7aca69d614cf0a5944c3ec606db96',
-                );
-                setArticles(response.data.articles);
+                // const response = await axios.get(
+                //     'https://newsapi.org/v2/everything?q=요소수&sortBy=publishedAt&pageSize=4&apiKey=a4a7aca69d614cf0a5944c3ec606db96',
+                // );
+                // setArticles(response.data.articles);
+                const response = await axios.get("/v1/search/news.json", {
+                    params: {
+                        query: '요소수',
+                        display: 6
+                    },
+                    headers: {
+                        'X-Naver-Client-Id': client_id,
+                        'X-Naver-Client-Secret': client_secret
+                    }
+                });
+                setArticles(response.data);
             } catch(e) {
                 console.log(e)
             }
@@ -54,7 +68,7 @@ const NewsList = () => {
     }
 
     // 아직 articles 값이 설정되지 않았을 때
-    if (!articles){
+    if (!articles) {
         return null;
     }
 
@@ -69,10 +83,13 @@ const NewsList = () => {
                         </div>
                     </div>
                 </Row>
-                <Row className="mt-3">
-                    {articles.map( article => (
+                <Row className="mt-3" style={{'textAlign':'center', 'fontWeight':'bold'}}>
+                    {/* {articles.map( article => (
                         <NewsItem key={ article.url } article={ article }/>
-                    ))}
+                    ))} */}
+                    {articles && articles.items.map( item => {
+                        return <p><a href={item.link}> {item.title} </a>{item.pubDate}</p>;
+                    })}
                 </Row>
             </div>
         </NewsListBlock>

--- a/Front/yososu_map/src/components/NewsPage/NewsList.js
+++ b/Front/yososu_map/src/components/NewsPage/NewsList.js
@@ -75,7 +75,7 @@ const NewsList = () => {
     // articles 값이 유효할 때
     return (
         <NewsListBlock>
-            <div className="container">
+            <div className="container" id="News">
                 <Row>
                     <div className="mt-5">
                         <div className="section-headline text-center">


### PR DESCRIPTION
### 구현한 기능
- Naver News API를 이용한 키워드 추출, 기존 newsAPI 코드 삭제

### 사용한 라이브러리
- proxy, naver api

### 대략적인 코드 설명
- 기존 newsapi의 권한으로는 localhost 말고 외부 서버로 이용이 불가능하다는 것을 인지(사용하게 하려면 한 달 53만원 내야함)
- naver api로 api 교체
- cors 정책 문제 해결
- 기존 Card 디자인이 먹히지 않아서 뉴스 타이틀에 하이퍼링크만 걸어서 나열 (css 적용이 잘 안먹히기에 시간 관계상 생략)