### PR TITLE
style: yososu map 타이틀 위치 가운데 정렬

### DIFF
--- a/Front/yososu_map/src/components/MapPage/MapPage.js
+++ b/Front/yososu_map/src/components/MapPage/MapPage.js
@@ -109,7 +109,7 @@ const MapPage = () => {
             <br></br>
             <Row>
                 <Col>
-                    <h1 className="title m-5">"Yososu Map"</h1>
+                    <h1 className="title m-5 text-center">"Yososu Map"</h1>
                     <div id="map" style={{ width: "auto", height:"500px" }}> </div>
                 </Col>
             </Row>


### PR DESCRIPTION
## 구현한 기능
- Yososu Map 텍스트 가운데 정렬

## 사용한 라이브러리

## 대략적인 코드 설명
- 아까 수정하고 나서 Yososu Map 타이틀이 왼쪽으로 정렬되던 현상이 발생해서 text-center 부여해서 재정렬